### PR TITLE
content event name support

### DIFF
--- a/src/react-konva.js
+++ b/src/react-konva.js
@@ -182,7 +182,7 @@ var NodeMixin = {
       var isEvent = key.slice(0, 2) === 'on';
       var propChanged = (oldProps[key] !== props[key]);
       if (isEvent && propChanged) {
-        this.node.off(key.slice(2, key.length).toLowerCase(), oldProps[key]);
+        this.node.off(key.substr(2, 1).toLowerCase() + key.substr(3), oldProps[key]);
       }
       var toRemove = !props.hasOwnProperty(key);
       if (toRemove) {
@@ -196,7 +196,7 @@ var NodeMixin = {
       var isEvent = key.slice(0, 2) === 'on';
       var toAdd = oldProps[key] !== props[key];
       if (isEvent && toAdd) {
-         this.node.on(key.slice(2, key.length).toLowerCase(), props[key]);
+         this.node.on(key.substr(2, 1).toLowerCase() + key.substr(3), props[key]);
       }
       if (!isEvent && ((props[key] !== oldProps[key]) || (props[key] !==  this.node.getAttr(key)))) {
         hasUpdates = true;

--- a/src/react-konva.js
+++ b/src/react-konva.js
@@ -182,7 +182,11 @@ var NodeMixin = {
       var isEvent = key.slice(0, 2) === 'on';
       var propChanged = (oldProps[key] !== props[key]);
       if (isEvent && propChanged) {
-        this.node.off(key.substr(2, 1).toLowerCase() + key.substr(3), oldProps[key]);
+        var eventName = key.substr(2).toLowerCase();
+        if (eventName.substr(7) === "content") {
+          eventName = eventName.substr(7) + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
+        }
+        this.node.off(eventName, oldProps[key]);
       }
       var toRemove = !props.hasOwnProperty(key);
       if (toRemove) {
@@ -196,7 +200,11 @@ var NodeMixin = {
       var isEvent = key.slice(0, 2) === 'on';
       var toAdd = oldProps[key] !== props[key];
       if (isEvent && toAdd) {
-         this.node.on(key.substr(2, 1).toLowerCase() + key.substr(3), props[key]);
+        var eventName = key.substr(2).toLowerCase();
+        if (eventName.substr(7) === "content") {
+          eventName = eventName.substr(7) + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
+        }
+        this.node.on(eventName, props[key]);
       }
       if (!isEvent && ((props[key] !== oldProps[key]) || (props[key] !==  this.node.getAttr(key)))) {
         hasUpdates = true;

--- a/src/react-konva.js
+++ b/src/react-konva.js
@@ -183,8 +183,8 @@ var NodeMixin = {
       var propChanged = (oldProps[key] !== props[key]);
       if (isEvent && propChanged) {
         var eventName = key.substr(2).toLowerCase();
-        if (eventName.substr(7) === "content") {
-          eventName = eventName.substr(7) + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
+        if (eventName.substr(0, 7) === "content") {
+          eventName = "content" + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
         }
         this.node.off(eventName, oldProps[key]);
       }
@@ -201,8 +201,8 @@ var NodeMixin = {
       var toAdd = oldProps[key] !== props[key];
       if (isEvent && toAdd) {
         var eventName = key.substr(2).toLowerCase();
-        if (eventName.substr(7) === "content") {
-          eventName = eventName.substr(7) + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
+        if (eventName.substr(0, 7) === "content") {
+          eventName = "content" + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
         }
         this.node.on(eventName, props[key]);
       }

--- a/test/tests.js
+++ b/test/tests.js
@@ -66,6 +66,31 @@ describe("Test stage component", function() {
     stage.simulateMouseDown({x: 50, y: 50});
     expect(eventCount).to.equal(1);
   });
+
+  it('can attach stage content events', function() {
+    let eventCount = 0;
+    const handleEvent = () => {
+      eventCount += 1;
+    };
+
+    class App extends React.Component {
+      render() {
+        return (
+          <Stage ref="stage" width="300" height="300" onContentMouseDown={handleEvent}>
+            <Layer ref="layer">
+              <Rect ref="rect" width={100} height={100}/>
+            </Layer>
+          </Stage>
+        );
+      }
+    }
+
+    const wrapper = mount(<App/>);
+    const instance = wrapper.instance();
+    const stage = instance.refs.stage.getStage();
+    stage.simulateMouseDown({x: 50, y: 50});
+    expect(eventCount).to.equal(1);
+  });
 });
 
 describe('Test props setting', function() {


### PR DESCRIPTION
I needed the onContent so I thought I would submit a patch. Rather than detect the presence of "content", I thought it would be better to only lowercase the first letter of the event name. This should be backwards compatible with the existing events, assuming people have camel-cased properly. I believe this is the same way that React itself handles events.