### PR TITLE
[WIP] add draggable to stage prop

### DIFF
--- a/react-konva.d.ts
+++ b/react-konva.d.ts
@@ -46,6 +46,7 @@ export interface StageProps extends Pick<React.HTMLProps<any>, 'className' | 'ro
   name?: string;
   width?: number | string;
   height?: number | string;
+  draggable?: boolean;
   onContentMouseOver?(evt: any): void;
   onContentMouseMove?(evt: any): void;
   onContentMouseOut?(evt: any): void;


### PR DESCRIPTION
did we need this? 
to fix 
```
    TS2339: Property 'draggable' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Stage> & Readonly<{ children?: ReactNode; }> & Rea...'.
```
error 
