### PR TITLE
Fix type build error

### DIFF
--- a/ReactKonvaCore.d.ts
+++ b/ReactKonvaCore.d.ts
@@ -102,4 +102,4 @@ export var Arrow: KonvaNodeComponent<Konva.Arrow, Konva.ArrowConfig>;
 export var Shape: KonvaNodeComponent<Konva.Shape, Konva.ShapeConfig>;
 
 export var useStrictMode: (useStrictMode: boolean) => void;
-export var KonvaRenderer: ReactReconciler.Reconciler<any, any, any, any, any>;
+export var KonvaRenderer: ReactReconciler.Reconciler<any, any, any, any, any, any>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "include": ["./src/**/*"],
   "files": [


### PR DESCRIPTION
Fixes #836

This PR also sets `skipLibCheck` to `false` so that this caught by the build in the future. This project is small enough that the performance penalty shouldn't be too high.