### PR TITLE
Fix headless chrome sandbox flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "preversion": "npm test",
     "version": "npm run build",
     "postversion": "",
-    "test": "NODE_ENV=test npm run test:build && mocha-headless-chrome -f ./test-build/unit-tests.html -a disable-web-security && npm run test:typings",
+    "test": "NODE_ENV=test npm run test:build && mocha-headless-chrome -f ./test-build/unit-tests.html -a disable-web-security -a no-sandbox -a disable-setuid-sandbox && npm run test:typings",
     "test:build": "rm -rf ./.parcel-cache && NODE_ENV=test parcel build ./test/unit-tests.html --dist-dir test-build --target none --public-url ./ --no-source-maps",
     "test:watch": "NODE_ENV=test rm -rf ./parcel-cache && parcel serve ./test/unit-tests.html"
   },


### PR DESCRIPTION
## Summary
- disable Chrome sandbox for headless tests so they can start in CI

## Testing
- `npm test` *(fails: TypeError/TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_68419b846428832daef77f3807de8e76